### PR TITLE
Make package compatible with Matplotlib versions > 3.6

### DIFF
--- a/timeseries_generator/base_factor.py
+++ b/timeseries_generator/base_factor.py
@@ -2,7 +2,12 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Optional, Union, Tuple
 
 from matplotlib.figure import Figure
-from matplotlib.axes._subplots import SubplotBase
+try:
+    # Matplotlib < 3.7
+    from matplotlib.axes._subplots import SubplotBase
+except ModuleNotFoundError:
+    # Matplotlib > 3.7
+    from matplotlib.axes import SubplotBase
 from matplotlib.pyplot import subplots
 from pandas import DataFrame, date_range, DatetimeIndex
 from pandas._libs.tslibs.timestamps import Timestamp


### PR DESCRIPTION
 In Matplotlib v 3.7 and later the submodule `matplotlib.axes._subplots` was removed. This breaks the `timeseries-generator.base_factor`, which contains:

```
from matplotlib.axes._subplots import SubplotBase
```

This MR fixes this for newer Matploltib versions.